### PR TITLE
Remove trailing whitespace from given URL

### DIFF
--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "URL Fetcher",
   "summary": "Fetches (and uploads) a file from a remote URL (suitable for retrieving public datasets, or data from your own HTTP/FTP server)",
   "dxapi": "1.0.0",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "inputSpec": [
     {
       "name": "url",

--- a/src/url_fetcher.py
+++ b/src/url_fetcher.py
@@ -129,6 +129,10 @@ def _find_appropriate_instance_type(file_size):
 def main(url, tags=None, properties=None, output_name=None):
     # Get the disk free space
     free_space = _get_free_space() / B_IN_MB
+
+    # Remove trailing whitespaces in the url
+    url = url.rstrip()
+
     # Get the filesize
     try:
         file_size = int(urllib.urlopen(url).info().getheaders('Content-Length')[0])


### PR DESCRIPTION
@godotgildor 

It's a really small change, but good to get another pair of eyes on this :)

## Problem
On some URLs that have a trailing whitespace, the URL fetcher will break due to a resource not found error from aria2c (whitespace is passed as unicode %20 suffixed to the given URL).

## Change
The given URL is rstrip-ed to remove trailing whitespace
