### PR TITLE
Improve url string handling

### DIFF
--- a/Readme.developer.md
+++ b/Readme.developer.md
@@ -1,5 +1,4 @@
-URLs are fetched using the <a
-href="http://aria2.sourceforge.net/">aria2c utility</a>. To achieve
+URLs are fetched using the [aria2c utility](http://aria2.sourceforge.net/). To achieve
 high speeds, 6 simultaneous connections are used when fetching the
 data.
 

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "URL Fetcher",
   "summary": "Fetches (and uploads) a file from a remote URL (suitable for retrieving public datasets, or data from your own HTTP/FTP server)",
   "dxapi": "1.0.0",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "inputSpec": [
     {
       "name": "url",

--- a/src/url_fetcher.py
+++ b/src/url_fetcher.py
@@ -44,10 +44,10 @@ def _get_free_space():
 
 @dxpy.entry_point('download_url')
 def download_url(url, tags=None, properties=None, output_name=None):
-    url = url.strip() # assume no URL has end/start whitespaces
+    url = url.strip()  # assume no URL has end/start whitespaces
     with dx_utils.cd():
         ariaCmd = ["aria2c", url, "--user-agent", "Mozilla/5.0", "-x6", "-j6", "--check-certificate=false", "--file-allocation=none"]
-        ariaCmd_str = " ",join(ariaCmd)
+        ariaCmd_str = " ".join(ariaCmd)
         print "Executing:\n{0}".format(ariaCmd_str)
         p = subprocess.Popen(
             ariaCmd,
@@ -146,7 +146,7 @@ def main(url, tags=None, properties=None, output_name=None):
         url_opener = NoPasswdPromptURLopener()
         url_info = url_opener.open(url).info()
 
-        file_size = int(url_info.getheaders('Content-Length')[0])        
+        file_size = int(url_info.getheaders('Content-Length')[0])
         file_size /= B_IN_MB
     except IndexError:
         # If we are not able to determine the size from the Content-Length

--- a/src/url_fetcher.py
+++ b/src/url_fetcher.py
@@ -21,6 +21,7 @@ import dxpy
 import subprocess
 import urllib
 import glob
+import pipes
 
 import dx_utils
 
@@ -47,7 +48,7 @@ def download_url(url, tags=None, properties=None, output_name=None):
     url = url.strip()  # assume no URL has end/start whitespaces
     with dx_utils.cd():
         ariaCmd = ["aria2c", url, "--user-agent", "Mozilla/5.0", "-x6", "-j6", "--check-certificate=false", "--file-allocation=none"]
-        ariaCmd_str = " ".join(ariaCmd)
+        ariaCmd_str = " ".join([pipes.quote(a) for a in ariaCmd])
         print "Executing:\n{0}".format(ariaCmd_str)
         p = subprocess.Popen(
             ariaCmd,

--- a/src/url_fetcher.py
+++ b/src/url_fetcher.py
@@ -44,6 +44,7 @@ def _get_free_space():
 
 @dxpy.entry_point('download_url')
 def download_url(url, tags=None, properties=None, output_name=None):
+    url = url.strip() # assume no URL has end/start whitespaces
     with dx_utils.cd():
         ariaCmd = ["aria2c", url, "--user-agent", "Mozilla/5.0", "-x6", "-j6", "--check-certificate=false", "--file-allocation=none"]
         ariaCmd_str = " ",join(ariaCmd)


### PR DESCRIPTION
**Motivation**

A while back there was an issue where a URL had an _"&"_, so when passed to the original aria `shell=True` subprocess would fail due to not being correctly quoted. Using `shell=True` places a greater burden of string sanitization on the applet developer. For example, the most recent commit solves the _"&"_ issue, but will fail if a URL with a quote (that has not been encoded) is passed.

**Changes**

* Changed the aria subprocess command to use array input and `shell=False`
* Minor changes, typos, unused imports, and subprocess report changed to `Popen.communicate()`

**Alternatives**
* Encode URLs using `urllib.quote`
* Have python correctly escape characters in string using [shlex.split()](https://docs.python.org/2/library/shlex.html#shlex.split)